### PR TITLE
Fix MyBatis migrations error `core.changelog` not exists

### DIFF
--- a/assets/migrations/environments/development.properties
+++ b/assets/migrations/environments/development.properties
@@ -62,7 +62,7 @@ full_line_delimiter=false
 # script is executed in one transaction.
 # Few databases should need this set to true,
 # but some do.
-auto_commit=true
+auto_commit=false
 
 # Custom driver path to allow you to centralize your driver files
 # Default requires the drivers to be in the drivers directory of your

--- a/assets/migrations/scripts/20200630123015_migrate_settings_data_into_settings_metadata_columns_uuid_json_setting_type_setting_value_setting_key_setting_description_inherited_from.sql
+++ b/assets/migrations/scripts/20200630123015_migrate_settings_data_into_settings_metadata_columns_uuid_json_setting_type_setting_value_setting_key_setting_description_inherited_from.sql
@@ -25,7 +25,7 @@ CREATE EXTENSION IF NOT EXISTS "uuid-ossp" schema core;
 
 -- remove document_id uniqueness constraint
 ALTER TABLE IF EXISTS core.settings_metadata
-    DROP CONSTRAINT IF EXISTS core.settings_metadata_document_id_key;
+    DROP CONSTRAINT IF EXISTS settings_metadata_document_id_key;
 
 CREATE OR REPLACE FUNCTION core.migrate_settings_json()
     RETURNS VOID


### PR DESCRIPTION
Fixed MyBatis migrations error on new machine:
```
relation "core.changelog" not exists
```